### PR TITLE
Use NPM_TOKEN instead of GITHUB_TOKEN for repository checkout authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NPM_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This PR updates the authentication token used in the repository checkout step from `GITHUB_TOKEN` to `NPM_TOKEN`.