### PR TITLE
Add WSO2_APIM_BOT_TOKEN instead of NPM_TOKEN for repository checkout authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.WSO2_APIM_BOT_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
This PR updates the authentication token used in the repository checkout step from NPM_TOKEN to WSO2_APIM_BOT_TOKEN.