### PR TITLE
Update release.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm i
 
       - name: Build package
         run: npm run build


### PR DESCRIPTION
This pull request updates the Node.js version and modifies the dependency installation command in the release workflow configuration.

* **Workflow updates:**
  * [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L45-R49): Updated the Node.js version from `18` to `22` for the `Setup Node.js` step.
  * [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L45-R49): Changed the dependency installation command from `npm ci` to `npm i` in the `Install dependencies` step.

- Related PR: https://github.com/wso2/wso2-mcp-playground/pull/7