### PR TITLE
Update release.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install dependencies
         run: npm i
 
+      - name: Install Rollup for amd64 Linux
+        run: npm install @rollup/rollup-linux-x64-gnu
+
       - name: Build package
         run: npm run build
 


### PR DESCRIPTION
This pull request updates the release workflow to include a new step for installing Rollup on amd64 Linux systems.

Workflow updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R51-R53): Added a step to install `@rollup/rollup-linux-x64-gnu` before building the package to ensure compatibility with amd64 Linux environments.

- Related PR: https://github.com/wso2/wso2-mcp-playground/pull/7