### PR TITLE
Add endpoint and visibility switcher, and improve layout and styling

### DIFF
--- a/src/app/MCPPlayground.tsx
+++ b/src/app/MCPPlayground.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { StyledEngineProvider } from '@mui/material/styles';
 import { StylesProvider, createGenerateClassName } from '@mui/styles';
 import useChoreoTheme from './theme/Theme.ts';
-import Playground from '../features/playground/Playground';
+import Playground, { Switcher } from '../features/playground/Playground';
 
 const mcpGenerateClassName = createGenerateClassName({
     productionPrefix: 'mcp',
@@ -23,6 +23,8 @@ interface PlaygroundProps {
     handleTokenRegenerate?: () => void;
     isMcpProxyWithOperationMapping?: boolean;
     tokenPlaceholder?: string;
+    endpointSwitcher?: Switcher;
+    visibilitySwitcher?: Switcher;
     theme?: ThemeOptions;
     injectStylesFirst?: boolean;
     emotionCache?: EmotionCache;

--- a/src/features/playground/Playground.tsx
+++ b/src/features/playground/Playground.tsx
@@ -285,18 +285,18 @@ const Playground = ({
             style={{
               display: "flex",
               flexDirection: "column",
+              position: "relative",
+              ...(mcpClient
+                ? {
+                    height: "auto",
+                    paddingBottom: 250,
+                  }
+                : {}),
             }}
           >
             {mcpClient ? (
               <>
-                {/* Main Content Area - Scrollable */}
-                <Box
-                  style={{
-                    flex: "1 1 auto",
-                    overflow: "auto",
-                    minHeight: 0,
-                  }}
-                >
+                <Box>
                   <Tabs
                     defaultValue="tools"
                     className="w-full p-4"

--- a/src/features/playground/Playground.tsx
+++ b/src/features/playground/Playground.tsx
@@ -213,7 +213,7 @@ const Playground = ({
     <Box className={classes.componentLevelPageContainer}>
       {!disableTitle && <Typography variant="h3">MCP Playground</Typography>}
       <Grid container md={12}>
-        <Grid item xs={12} md={3} className={classes.playgroundSlider}>
+        <Grid item xs={12} md={4} className={classes.playgroundSlider}>
           <Sidebar
             connectionStatus={connectionStatus}
             connectionError={connectionError}

--- a/src/features/playground/Playground.tsx
+++ b/src/features/playground/Playground.tsx
@@ -51,6 +51,7 @@ interface PlaygroundProps {
   disableConnectionButton?: boolean;
   endpointSwitcher?: Switcher;
   visibilitySwitcher?: Switcher;
+  disconnectOnUrlChange?: boolean;
   theme?: ThemeOptions;
 }
 
@@ -70,6 +71,7 @@ const Playground = ({
   disableConnectionButton,
   endpointSwitcher,
   visibilitySwitcher,
+  disconnectOnUrlChange,
   theme,
 }: PlaygroundProps) => {
   const classes = useStyles();
@@ -87,8 +89,30 @@ const Playground = ({
     tools: null,
   });
 
+  const isInitialUrlRef = useRef(true);
   useEffect(() => {
-    setUrl(initialUrl || "");
+    if (isInitialUrlRef.current) {
+      isInitialUrlRef.current = false;
+      setUrl(initialUrl || "");
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      if (disconnectOnUrlChange && connectionStatus === "connected") {
+        await disconnectMcpServer();
+        setTools([]);
+        setSelectedTool(null);
+        setNextToolCursor(undefined);
+        cacheToolOutputSchemas([]);
+        clearHistory();
+      }
+      if (!cancelled) {
+        setUrl(initialUrl || "");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [initialUrl]);
 
   useEffect(() => {

--- a/src/features/playground/Playground.tsx
+++ b/src/features/playground/Playground.tsx
@@ -23,6 +23,18 @@ import ToolsTab from "./components/ToolsTab";
 import HistoryPanel from "./components/HistoryPanel";
 import { useStyles } from "./style";
 
+export type SwitcherOption = {
+  label: string;
+  value: string;
+};
+
+export type Switcher = {
+  label?: string;
+  options: SwitcherOption[];
+  value: string;
+  onChange: (value: string) => void;
+};
+
 interface PlaygroundProps {
   url?: string;
   token?: string;
@@ -37,6 +49,8 @@ interface PlaygroundProps {
   enableConfiguration?: boolean;
   onConfigurationClick?: () => void;
   disableConnectionButton?: boolean;
+  endpointSwitcher?: Switcher;
+  visibilitySwitcher?: Switcher;
   theme?: ThemeOptions;
 }
 
@@ -54,6 +68,8 @@ const Playground = ({
   enableConfiguration,
   onConfigurationClick,
   disableConnectionButton,
+  endpointSwitcher,
+  visibilitySwitcher,
   theme,
 }: PlaygroundProps) => {
   const classes = useStyles();
@@ -235,6 +251,8 @@ const Playground = ({
             enableConfiguration={enableConfiguration}
             onConfigurationClick={onConfigurationClick}
             disableConnectionButton={disableConnectionButton}
+            endpointSwitcher={endpointSwitcher}
+            visibilitySwitcher={visibilitySwitcher}
           />
         </Grid>
         <Grid item xs={12} md={8} className={classes.playgroundRightSlider}>

--- a/src/features/playground/Playground.tsx
+++ b/src/features/playground/Playground.tsx
@@ -100,15 +100,15 @@ const Playground = ({
     (async () => {
       if (disconnectOnUrlChange && connectionStatus === "connected") {
         await disconnectMcpServer();
+        if (cancelled) return;
         setTools([]);
         setSelectedTool(null);
         setNextToolCursor(undefined);
         cacheToolOutputSchemas([]);
         clearHistory();
       }
-      if (!cancelled) {
-        setUrl(initialUrl || "");
-      }
+      if (cancelled) return;
++     setUrl(initialUrl || "");
     })();
     return () => {
       cancelled = true;

--- a/src/features/playground/components/HistoryPanel.tsx
+++ b/src/features/playground/components/HistoryPanel.tsx
@@ -17,6 +17,11 @@ const useStyles = makeStyles((theme: any) => ({
     display: 'flex',
     flexDirection: 'column',
     overflow: 'hidden',
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
   },
   historyHeader: {
     padding: theme.spacing(1),
@@ -139,11 +144,6 @@ const HistoryPanel: React.FC<HistoryPanelProps> = ({ history }) => {
     <Box
       className={classes.historyContainer}
       style={{
-        position: 'absolute',
-        bottom: 0,
-        left: 0,
-        right: 0,
-        zIndex: 10,
         height: `${height}px`,
       }}
     >

--- a/src/features/playground/components/HistoryPanel.tsx
+++ b/src/features/playground/components/HistoryPanel.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme: any) => ({
     overflow: 'hidden',
   },
   historyHeader: {
-    padding: theme.spacing(1, 1, 1, 1),
+    padding: theme.spacing(1),
     borderBottom: '1px solid #e5e7eb',
     display: 'flex',
     justifyContent: 'space-between',

--- a/src/features/playground/components/HistoryPanel.tsx
+++ b/src/features/playground/components/HistoryPanel.tsx
@@ -11,21 +11,20 @@ interface HistoryPanelProps {
 
 const useStyles = makeStyles((theme: any) => ({
   historyContainer: {
-    borderRadius: '8px 8px 0 0',
+    borderRadius: '8px',
     border: '1px solid #e5e7eb',
     backgroundColor: '#fff',
-    borderBottom: 'none', // Remove bottom border since resize handle provides it
     display: 'flex',
     flexDirection: 'column',
+    overflow: 'hidden',
   },
   historyHeader: {
-    padding: theme.spacing(1, 2),
+    padding: theme.spacing(1, 1, 1, 1),
     borderBottom: '1px solid #e5e7eb',
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
     backgroundColor: '#fff',
-    borderRadius: '8px 8px 0 0',
     flexShrink: 0,
   },
   historyTitle: {
@@ -137,19 +136,22 @@ const HistoryPanel: React.FC<HistoryPanelProps> = ({ history }) => {
   };
 
   return (
-    <Box>
-      {/* Resize Handle */}
-      <ResizeHandle 
+    <Box
+      className={classes.historyContainer}
+      style={{
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 10,
+        height: `${height}px`,
+      }}
+    >
+      <ResizeHandle
         onMouseDown={resizeHandleProps.onMouseDown}
         isResizing={isResizing}
       />
-      
-      {/* History Panel Container */}
-      <Box 
-        className={classes.historyContainer}
-        style={{ height: `${height}px` }}
-      >
-        <Box className={classes.historyHeader}>
+      <Box className={classes.historyHeader}>
           <Typography className={classes.historyTitle}>
             Activity History
           </Typography>
@@ -214,7 +216,6 @@ const HistoryPanel: React.FC<HistoryPanelProps> = ({ history }) => {
             </div>
           )}
         </div>
-      </Box>
     </Box>
   );
 };

--- a/src/features/playground/components/JsonView.tsx
+++ b/src/features/playground/components/JsonView.tsx
@@ -1,10 +1,8 @@
 import { useState, memo, useMemo, useCallback, useEffect } from 'react';
 import { Box } from '@mui/material';
 import clsx from 'clsx';
-import {
-  Copy,
-  Tick,
-} from './ui/Icons/generated';
+import { Copy } from './ui/Icons/generated';
+import CheckIcon from "@mui/icons-material/Check";
 import JsonViewer from './ui/JsonViewer/JsonViewer';
 import IconButton from './ui/IconButton/IconButton';
 import type { JsonValue } from '../utils/jsonUtils';
@@ -94,13 +92,17 @@ const JsonView = memo(
         <Box>
           {withCopyButton && (
             <IconButton
-              variant="subtle"
+              variant="text"
               className={classes.copyButton}
+              sx={{
+                position: 'absolute',
+                padding: '2px',
+              }}
               onClick={handleCopy}
               testId="playground-response-copy"
             >
               {copied ? (
-                <Tick className={classes.copySuccessIcon} />
+                <CheckIcon fontSize="small" />
               ) : (
                 <Copy className={classes.copyIcon} />
               )}

--- a/src/features/playground/components/JsonView.tsx
+++ b/src/features/playground/components/JsonView.tsx
@@ -96,7 +96,7 @@ const JsonView = memo(
               className={classes.copyButton}
               sx={{
                 position: 'absolute',
-                padding: '2px',
+                p: 0.25,
               }}
               onClick={handleCopy}
               testId="playground-response-copy"

--- a/src/features/playground/components/ResizeHandle.tsx
+++ b/src/features/playground/components/ResizeHandle.tsx
@@ -9,21 +9,18 @@ interface ResizeHandleProps {
 
 const useStyles = makeStyles((theme: any) => ({
   resizeHandle: {
-    height: '8px',
+    height: theme.spacing(1.5),
     width: '100%',
-    backgroundColor: 'transparent',
+    backgroundColor: '#fff',
     cursor: 'row-resize',
-    borderTop: '1px solid #e0e0e0',
-    borderBottom: '1px solid #e0e0e0',
     position: 'relative',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    transition: 'all 0.2s ease',
+    transition: 'background-color 0.2s ease',
+    flexShrink: 0,
     '&:hover': {
-      backgroundColor: 'rgba(25, 118, 210, 0.08)', // Light blue hover
-      borderTopColor: theme.palette.primary.main,
-      borderBottomColor: theme.palette.primary.main,
+      backgroundColor: 'rgba(25, 118, 210, 0.06)',
     },
     '&:hover $dragIndicator': {
       opacity: 1,
@@ -32,8 +29,6 @@ const useStyles = makeStyles((theme: any) => ({
   },
   resizing: {
     backgroundColor: 'rgba(25, 118, 210, 0.12)',
-    borderTopColor: theme.palette.primary.main,
-    borderBottomColor: theme.palette.primary.main,
     '& $dragIndicator': {
       opacity: 1,
       transform: 'scaleY(1.2)',
@@ -42,31 +37,10 @@ const useStyles = makeStyles((theme: any) => ({
   dragIndicator: {
     width: '40px',
     height: '3px',
-    backgroundColor: theme.palette.grey[400],
+    backgroundColor: theme.palette.grey[500] || '#9ca3af',
     borderRadius: '2px',
-    opacity: 0.4,
+    opacity: 0.6,
     transition: 'all 0.2s ease',
-    position: 'relative',
-    '&::before': {
-      content: '""',
-      position: 'absolute',
-      top: '-2px',
-      left: '0',
-      right: '0',
-      height: '1px',
-      backgroundColor: theme.palette.grey[300],
-      borderRadius: '1px',
-    },
-    '&::after': {
-      content: '""',
-      position: 'absolute',
-      bottom: '-2px',
-      left: '0',
-      right: '0',
-      height: '1px',
-      backgroundColor: theme.palette.grey[300],
-      borderRadius: '1px',
-    },
   },
 }));
 

--- a/src/features/playground/components/Sidebar.tsx
+++ b/src/features/playground/components/Sidebar.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { Box, CircularProgress, InputAdornment } from "@mui/material";
+import {
+  Box,
+  CircularProgress,
+  InputAdornment,
+} from "@mui/material";
 import IconButton from "./ui/IconButton/IconButton";
 import TextInput from "./ui/TextInput/TextInput";
+import Switcher from "./ui/Switcher/Switcher";
 import Button from "./ui/Button/Button";
 import {
   Configuration,
@@ -12,6 +17,7 @@ import {
   MenuSubAPIManagement,
 } from "./ui/Icons/generated";
 import { ConnectionStatus } from "../lib/constants";
+import { Switcher as SwitcherType } from "../Playground";
 
 interface SidebarProps {
   connectionStatus: ConnectionStatus;
@@ -32,6 +38,8 @@ interface SidebarProps {
   enableConfiguration?: boolean;
   onConfigurationClick?: () => void;
   disableConnectionButton?: boolean;
+  endpointSwitcher?: SwitcherType;
+  visibilitySwitcher?: SwitcherType;
 }
 
 const Sidebar = ({
@@ -52,7 +60,9 @@ const Sidebar = ({
   tokenPlaceholder,
   enableConfiguration,
   onConfigurationClick,
-  disableConnectionButton
+  disableConnectionButton,
+  endpointSwitcher,
+  visibilitySwitcher,
 }: SidebarProps) => {
   const [showBearerToken, setShowBearerToken] = useState(false);
   const [showPassword, toggleInputType] = React.useState(false);
@@ -65,6 +75,20 @@ const Sidebar = ({
       <Box width="100%" maxWidth={400} mx="auto">
         <Box display="flex" flexDirection="column" gap={3}>
           <Box mb={2} display="flex" flexDirection="column" gap={3}>
+            {endpointSwitcher && (
+              <Switcher
+                switcher={endpointSwitcher}
+                defaultLabel="Endpoint"
+                testId="endpoint-switcher"
+              />
+            )}
+            {visibilitySwitcher && (
+              <Switcher
+                switcher={visibilitySwitcher}
+                defaultLabel="Visibility"
+                testId="visibility-switcher"
+              />
+            )}
             {isUrlFetching ? (
               <Box
                 display="flex"

--- a/src/features/playground/components/Sidebar.tsx
+++ b/src/features/playground/components/Sidebar.tsx
@@ -147,49 +147,44 @@ const Sidebar = ({
                 placeholder="Enter Header Name"
               />
             )}
-            {isTokenFetching ? (
-              <Box
-                display="flex"
-                justifyContent="center"
-                alignItems="center"
-                minHeight="60px"
-              >
-                <CircularProgress size={30} />
-              </Box>
-            ) : (
-              <TextInput
-                label="Token"
-                testId="Authentication-Bearer-Token"
-                fullWidth
-                value={token}
-                type={showPassword ? "text" : "password"}
-                onChange={(e) => setToken(e.target.value)}
-                placeholder={tokenPlaceholder || "Add Your Token"}
-                endAdornment={
-                  <InputAdornment position="end">
-                    <IconButton
-                      onClick={handleEndButtonClick}
-                      size="small"
-                      variant="text"
-                      color="primary"
-                      testId="secret"
-                    >
-                      {showPassword ? <ShowPassword /> : <HidePassword />}
-                    </IconButton>
-                    <IconButton
-                      onClick={() => handleCopy("token", token)}
-                      size="small"
-                      variant="text"
-                      color="primary"
-                      testId="copy-token"
-                      disabled={!token}
-                    >
-                      {copiedField === "token" ? <CheckIcon fontSize="small" /> : <Copy />}
-                    </IconButton>
-                  </InputAdornment>
-                }
-              />
-            )}
+            <TextInput
+              label="Token"
+              testId="Authentication-Bearer-Token"
+              fullWidth
+              value={token}
+              type={showPassword ? "text" : "password"}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder={tokenPlaceholder || "Add Your Token"}
+              disabled={isTokenFetching}
+              endAdornment={
+                <InputAdornment position="end">
+                  {isTokenFetching && (
+                    <Box display="flex" alignItems="center" mx={0.5}>
+                      <CircularProgress size={16} />
+                    </Box>
+                  )}
+                  <IconButton
+                    onClick={handleEndButtonClick}
+                    size="small"
+                    variant="text"
+                    color="primary"
+                    testId="secret"
+                  >
+                    {showPassword ? <ShowPassword /> : <HidePassword />}
+                  </IconButton>
+                  <IconButton
+                    onClick={() => handleCopy("token", token)}
+                    size="small"
+                    variant="text"
+                    color="primary"
+                    testId="copy-token"
+                    disabled={!token}
+                  >
+                    {copiedField === "token" ? <CheckIcon fontSize="small" /> : <Copy />}
+                  </IconButton>
+                </InputAdornment>
+              }
+            />
             {handleTokenRegenerate && (
               <Box mt={1}>
                 <Button

--- a/src/features/playground/components/Sidebar.tsx
+++ b/src/features/playground/components/Sidebar.tsx
@@ -4,12 +4,14 @@ import {
   CircularProgress,
   InputAdornment,
 } from "@mui/material";
+import CheckIcon from "@mui/icons-material/Check";
 import IconButton from "./ui/IconButton/IconButton";
 import TextInput from "./ui/TextInput/TextInput";
 import Switcher from "./ui/Switcher/Switcher";
 import Button from "./ui/Button/Button";
 import {
   Configuration,
+  Copy,
   HidePassword,
   MenuLogout,
   Refresh,
@@ -66,9 +68,35 @@ const Sidebar = ({
 }: SidebarProps) => {
   const [showBearerToken, setShowBearerToken] = useState(false);
   const [showPassword, toggleInputType] = React.useState(false);
+  const [copiedField, setCopiedField] = useState<"url" | "token" | null>(null);
   const handleEndButtonClick = () => {
     toggleInputType(!showPassword);
   };
+
+  const handleCopy = (field: "url" | "token", value?: string) => {
+    if (!value) return;
+    navigator.clipboard.writeText(value).then(() => {
+      setCopiedField(field);
+      setTimeout(() => {
+        setCopiedField((current) => (current === field ? null : current));
+      }, 1500);
+    });
+  };
+
+  const renderCopyAdornment = (field: "url" | "token", value?: string) => (
+    <InputAdornment position="end">
+      <IconButton
+        onClick={() => handleCopy(field, value)}
+        size="small"
+        variant="text"
+        color="primary"
+        testId={`copy-${field}`}
+        disabled={!value}
+      >
+        {copiedField === field ? <CheckIcon fontSize="small" /> : <Copy />}
+      </IconButton>
+    </InputAdornment>
+  );
 
   return (
     <Box>
@@ -106,6 +134,7 @@ const Sidebar = ({
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}
                 placeholder="Enter URL"
+                endAdornment={renderCopyAdornment("url", url)}
               />
             )}
             {shouldSetHeaderNameExternally && (
@@ -146,6 +175,16 @@ const Sidebar = ({
                       testId="secret"
                     >
                       {showPassword ? <ShowPassword /> : <HidePassword />}
+                    </IconButton>
+                    <IconButton
+                      onClick={() => handleCopy("token", token)}
+                      size="small"
+                      variant="text"
+                      color="primary"
+                      testId="copy-token"
+                      disabled={!token}
+                    >
+                      {copiedField === "token" ? <CheckIcon fontSize="small" /> : <Copy />}
                     </IconButton>
                   </InputAdornment>
                 }

--- a/src/features/playground/components/Sidebar.tsx
+++ b/src/features/playground/components/Sidebar.tsx
@@ -155,7 +155,7 @@ const Sidebar = ({
               <Box mt={1}>
                 <Button
                   fullWidth
-                  variant="subtle"
+                  variant="outlined"
                   onClick={handleTokenRegenerate}
                   data-testid="auth-button"
                   aria-expanded={showBearerToken}

--- a/src/features/playground/components/ToolsTab.tsx
+++ b/src/features/playground/components/ToolsTab.tsx
@@ -8,7 +8,6 @@ import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import React, { useEffect, useState } from 'react';
 import { Box, CircularProgress, Typography } from '@mui/material';
 import Notification from './ui/Notification/Notification';
-import { Promote } from './ui/Icons/generated';
 import TextInput from './ui/TextInput/TextInput';
 import Button from './ui/Button/Button';
 import Checkbox from './ui/Checkbox/Checkbox';

--- a/src/features/playground/components/ToolsTab.tsx
+++ b/src/features/playground/components/ToolsTab.tsx
@@ -6,7 +6,7 @@ import {
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import React, { useEffect, useState } from 'react';
-import { Box, CircularProgress, Grid, Typography } from '@mui/material';
+import { Box, CircularProgress, Typography } from '@mui/material';
 import Notification from './ui/Notification/Notification';
 import { Promote } from './ui/Icons/generated';
 import TextInput from './ui/TextInput/TextInput';
@@ -20,6 +20,7 @@ import ListPane from './ListPane';
 import JsonView from './JsonView';
 import ToolResults from './ToolResults';
 import { useStyles } from './style';
+import { PlayArrowRounded } from '@mui/icons-material';
 
 const ToolsTab = ({
   tools,
@@ -59,8 +60,8 @@ const ToolsTab = ({
 
   return (
     <TabsContent value="tools">
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={6} className={classes.toolPanel}>
+      <Box className={classes.toolsLayout}>
+        <Box className={classes.toolPanel}>
           <ListPane
             items={tools}
             listItems={listTools}
@@ -86,8 +87,8 @@ const ToolsTab = ({
             buttonText={nextCursor ? 'List More Tools' : 'List Tools'}
             isButtonDisabled={!nextCursor && tools.length > 0}
           />
-        </Grid>
-        <Grid item xs={12} md={6}>
+        </Box>
+        <Box className={classes.toolPanel}>
           <Box className={classes.resultSection}>
             <Box className={classes.resultSectionHeader}>
               <Typography variant="h4">
@@ -297,7 +298,7 @@ const ToolsTab = ({
                         }}
                         disabled={isToolRunning}
                         testId="run-tool-btn"
-                        startIcon={<Promote className="w-4 h-4" />}
+                        startIcon={<PlayArrowRounded fontSize='inherit'/>}
                       >
                         Run Tool
                       </Button>
@@ -315,8 +316,8 @@ const ToolsTab = ({
               </div>
             )}
           </Box>
-        </Grid>
-      </Grid>
+        </Box>
+      </Box>
     </TabsContent>
   );
 };

--- a/src/features/playground/components/style.ts
+++ b/src/features/playground/components/style.ts
@@ -31,20 +31,34 @@ export const useStyles = makeStyles((theme: any) => ({
     border: `1px solid ${theme.palette.grey[200]}`,
     marginTop: theme.spacing(1),
   },
+  toolsLayout: {
+    display: 'flex',
+    gap: theme.spacing(2),
+    alignItems: 'stretch',
+    flexDirection: 'column',
+    [theme.breakpoints.up('md')]: {
+      flexDirection: 'row',
+    },
+  },
   toolPanel: {
-    // borderRight: `1px solid ${theme.palette.grey[200]}`,
+    display: 'flex',
+    flex: 1,
+    minWidth: 0,
+    padding: 0,
   },
   resultSection: {
     borderRadius: 8,
     border: '1px solid #e5e7eb',
     backgroundColor: '#fff',
     marginTop: theme.spacing(1),
+    flex: 1,
   },
   resultSectionHeader: {
     padding: theme.spacing(1, 2),
     borderBottom: '1px solid #e5e7eb',
     display: 'flex',
     justifyContent: 'space-between',
+    alignItems: 'center',
   },
   title: {
     fontWeight: 600,
@@ -80,11 +94,9 @@ export const useStyles = makeStyles((theme: any) => ({
     border: `1px solid ${theme.palette.grey[200]}`,
   },
   copyButton: {
-    position: 'absolute',
     top: 8,
     right: 8,
     minWidth: 0,
-    padding: 6,
   },
   copyIcon: {
     fontSize: 16,

--- a/src/features/playground/components/ui/Switcher/Switcher.tsx
+++ b/src/features/playground/components/ui/Switcher/Switcher.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Box, InputBase, MenuItem, Select, Typography } from "@mui/material";
+import useTextFiledStyles from "../TextInput/TextInput.styles";
+import { Switcher as SwitcherType } from "../../../Playground";
+
+interface SwitcherProps {
+  switcher: SwitcherType;
+  defaultLabel: string;
+  testId: string;
+}
+
+const Switcher = ({ switcher, defaultLabel, testId }: SwitcherProps) => {
+  const classes = useTextFiledStyles({} as any);
+
+  return (
+    <Box>
+      <Box className={classes.formLabel}>
+        <Typography component="h6" variant="body1">
+          {switcher.label || defaultLabel}
+        </Typography>
+      </Box>
+      <Select
+        fullWidth
+        data-testid={testId}
+        value={switcher.value}
+        onChange={(e) => switcher.onChange(e.target.value as string)}
+        MenuProps={{
+          disableScrollLock: true,
+          BackdropProps: { sx: { backgroundColor: "transparent" } },
+        }}
+        input={
+          <InputBase
+            classes={{
+              root: classes.root,
+              focused: classes.focused,
+              input: classes.textInput,
+            }}
+          />
+        }
+      >
+        {switcher.options.map((option) => (
+          <MenuItem key={option.value} value={option.value}>
+            {option.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </Box>
+  );
+};
+
+export default Switcher;

--- a/src/features/playground/components/ui/Switcher/Switcher.tsx
+++ b/src/features/playground/components/ui/Switcher/Switcher.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Box, InputBase, MenuItem, Select, Typography } from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import useTextFiledStyles from "../TextInput/TextInput.styles";
 import { Switcher as SwitcherType } from "../../../Playground";
 
@@ -24,9 +25,11 @@ const Switcher = ({ switcher, defaultLabel, testId }: SwitcherProps) => {
         data-testid={testId}
         value={switcher.value}
         onChange={(e) => switcher.onChange(e.target.value as string)}
+        IconComponent={ExpandMoreIcon}
         MenuProps={{
           disableScrollLock: true,
           BackdropProps: { sx: { backgroundColor: "transparent" } },
+          MenuListProps: { sx: { py: 0 } },
         }}
         input={
           <InputBase
@@ -35,11 +38,27 @@ const Switcher = ({ switcher, defaultLabel, testId }: SwitcherProps) => {
               focused: classes.focused,
               input: classes.textInput,
             }}
+            sx={{
+              "& .MuiSelect-select": {
+                border: "none",
+                background: "transparent",
+                boxShadow: "none",
+                minHeight: 0,
+                "&:focus": {
+                  background: "transparent",
+                  boxShadow: "none",
+                },
+              },
+            }}
           />
         }
       >
         {switcher.options.map((option) => (
-          <MenuItem key={option.value} value={option.value}>
+          <MenuItem
+            key={option.value}
+            value={option.value}
+            sx={{ py: 1.5 }}
+          >
             {option.label}
           </MenuItem>
         ))}

--- a/src/features/playground/components/ui/Switcher/Switcher.tsx
+++ b/src/features/playground/components/ui/Switcher/Switcher.tsx
@@ -1,4 +1,15 @@
-import React from "react";
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+ *
+ * This software is the property of WSO2 LLC. and its suppliers, if any.
+ * Dissemination of any information or reproduction of any material contained
+ * herein is strictly forbidden, unless permitted by WSO2 in accordance with
+ * the WSO2 Commercial License available at http://wso2.com/licenses.
+ * For specific language governing the permissions and limitations under
+ * this license, please see the license as well as any agreement you’ve
+ * entered into with WSO2 governing the purchase of this software and any
+ * associated services.
+ */
 import { Box, InputBase, MenuItem, Select, Typography } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import useTextFiledStyles from "../TextInput/TextInput.styles";

--- a/src/features/playground/style.ts
+++ b/src/features/playground/style.ts
@@ -38,7 +38,6 @@ export const useStyles = makeStyles((theme: any) => ({
   playgroundResult: {
     overflow: 'auto',
     height: '100%',
-    borderBottom: `1px solid ${theme.palette.grey[200]}`,
   },
   tabsList: {
     display: 'flex',
@@ -60,6 +59,7 @@ export const useStyles = makeStyles((theme: any) => ({
     backgroundColor: 'transparent',
     transition: 'all 0.2s ease',
     border: '1px solid transparent',
+    cursor: 'pointer',
 
     '&:hover': {
       backgroundColor: '#f1f5f9',


### PR DESCRIPTION
## Purpose

Make the MCP Playground embeddable in host apps and fix layout issues that surface when it's used in another project.

  - Add optional `endpointSwitcher`, `visibilitySwitcher`, and `disconnectOnUrlChange` props so the host can drive context (endpoint / visibility drop downs) and trigger a clean disconnect when the connection URL changes.
  - Add copy buttons to the URL and Token fields, and move the token-fetch spinner inline so the field stays preventing major layout shifts.
  - Replace the `<Grid container spacing={2}>` row in ToolsTab with a native flex `<Box>` (gap + responsive direction). This stops the host's inherited
  `.MuiGrid-spacing-xs-2 > .MuiGrid-item { padding: 8px }` from breaking the panels, and gives them equal height via flex stretch.
  - Make the history panel an absolute-positioned overlay anchored to the bottom of the right pane, with the resize handle merged into its top edge, resizing it taller overlays the main content instead of squeezing it.
  - Minor visual polish: MUI `PlayArrowRounded` for Run Tool, MUI `CheckIcon` for copy-success states, `ExpandMoreIcon` caret on the new Switcher, and `outlined` variant on the Get Test Key button.

## Preview

https://github.com/user-attachments/assets/aa8e2f42-9c9c-48d6-82f6-6895470bebf5


